### PR TITLE
CSRF対策

### DIFF
--- a/error.php
+++ b/error.php
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>ショッピングサイト</title>
+  </head>
+
+  <body>
+    エラーが発生しました。<br/>
+    もう一度登録を初めからやり直してください。
+  </body>

--- a/staff/staff_add_check.php
+++ b/staff/staff_add_check.php
@@ -25,6 +25,12 @@
 
   <?php
 
+  function get_csrf_token() {
+  $TOKEN_LENGTH = 16;
+  $bytes = openssl_random_pseudo_bytes($TOKEN_LENGTH);
+  return bin2hex($bytes);
+  $_SESSION['token'] = get_csrf_token();
+  }
     require_once('../common/common.php');
 
     $post=sanitize($_POST);
@@ -65,6 +71,7 @@
         print '<form method="post" action="staff_add_done.php">';
         print '<input type="hidden" name="name" value="'.$staff_name.'">';
         print '<input type="hidden" name="pass" value="'.$staff_pass.'">';
+        print '<input type="hidden" name="token" value="'.$_SESSION['token'].'">';
         print '<br/>';
         print '<input type="button" onclick="history.back()" value="戻る">';
         print '<input type="submit" value="ＯＫ">';

--- a/staff/staff_add_done.php
+++ b/staff/staff_add_done.php
@@ -24,7 +24,20 @@
   <body>
 
   <?php
-  
+    function get_csrf_token() {
+      $TOKEN_LENGTH = 16;
+      $bytes = openssl_random_pseudo_bytes($TOKEN_LENGTH);
+      return bin2hex($bytes);
+      $_SESSION['token'] = get_csrf_token();
+      }
+      $token = $_POST['token'];
+
+      if ($token != $_SESSION['token']) {
+        header('HTTP/1.1 301 Moved Permanently');
+        header('Location: ../error.php');
+        exit();
+      }
+
   try 
   {
 


### PR DESCRIPTION
CSRF対策として、確認画面でトークンを送信し、登録画面でトークンを受信する方法を取った。